### PR TITLE
Refactored database secret block.

### DIFF
--- a/charts/datalore/Chart.yaml
+++ b/charts/datalore/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: datalore
 
 type: application
-version: 0.2.5
+version: 0.2.4-SNAPSHOT
 appVersion: "2022.2.2"

--- a/charts/datalore/Chart.yaml
+++ b/charts/datalore/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: datalore
 
 type: application
-version: 0.2.4-SNAPSHOT
+version: 0.2.5
 appVersion: "2022.2.2"

--- a/charts/datalore/templates/_helpers.tpl
+++ b/charts/datalore/templates/_helpers.tpl
@@ -62,5 +62,5 @@ Create the name of the service account to use
 Create the name of the database secret to use
 */}}
 {{- define "datalore.databaseSecretName" -}}
-{{- default (include "datalore.fullname" .) .Values.databaseSecret.name }}
+{{- default (printf "%s-db" (include "datalore.fullname" .)) .Values.databaseSecret.name }}
 {{- end }}

--- a/charts/datalore/templates/_helpers.tpl
+++ b/charts/datalore/templates/_helpers.tpl
@@ -57,3 +57,10 @@ Create the name of the service account to use
 {{- define "datalore.serviceAccountName" -}}
 {{- default (include "datalore.fullname" .) .Values.serviceAccount.name }}
 {{- end }}
+
+{{/*
+Create the name of the database secret to use
+*/}}
+{{- define "datalore.databaseSecretName" -}}
+{{- default (include "datalore.fullname" .) .Values.databaseSecret.name }}
+{{- end }}

--- a/charts/datalore/templates/db-secret.yaml
+++ b/charts/datalore/templates/db-secret.yaml
@@ -1,8 +1,15 @@
+{{- if .Values.databaseSecret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "datalore.fullname" . }}-db
+  name: {{ include "datalore.databaseSecretName" . }}
   labels:
     {{- include "datalore.labels" . | nindent 4 }}
+  {{- with .Values.databaseSecret.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
-  ROOT_PASSWORD: {{ required "A valid .Values.dbRootPassword entry required!" .Values.dbRootPassword | b64enc }}
+  {{- $password := required "A valid .Values.databaseSecret.password entry required!" .Values.databaseSecret.password }}
+  {{- b64enc $password | dict .Values.databaseSecret.key | toYaml | nindent 2 }}
+{{- end }}

--- a/charts/datalore/templates/statefulset.yaml
+++ b/charts/datalore/templates/statefulset.yaml
@@ -111,8 +111,8 @@ spec:
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "datalore.fullname" . }}-db
-                  key: ROOT_PASSWORD
+                  name: {{ include "datalore.databaseSecretName" . }}
+                  key: {{ quote .Values.databaseSecret.key }}
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: postgresql-data

--- a/charts/datalore/templates/statefulset.yaml
+++ b/charts/datalore/templates/statefulset.yaml
@@ -54,8 +54,8 @@ spec:
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "datalore.fullname" . }}-db
-                  key: ROOT_PASSWORD
+                  name: {{ include "datalore.databaseSecretName" . }}
+                  key: {{ quote .Values.databaseSecret.key }}
             - name: DATABASES_CONNECTION_CHECKER_K8S_YAML
               value: file:///opt/datalore/configs/databases/connection_checker.yaml
             - name: DATABASES_INTROSPECTION_K8S_YAML

--- a/charts/datalore/values.yaml
+++ b/charts/datalore/values.yaml
@@ -86,7 +86,7 @@ affinity: {}
 
 databaseSecret:
   # Specifies whether a secret should be created
-  create: false
+  create: true
   # Annotations to add to the secret
   annotations: {}
   # The name of the secret to use.

--- a/charts/datalore/values.yaml
+++ b/charts/datalore/values.yaml
@@ -84,7 +84,19 @@ tolerations: []
 
 affinity: {}
 
-dbRootPassword: ""
+databaseSecret:
+  # Specifies whether a secret should be created
+  create: false
+  # Annotations to add to the secret
+  annotations: {}
+  # The name of the secret to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # Set if create is true
+  password: ""
+  # Secret key name with a password for PostgreSQL
+  key: ROOT_PASSWORD
+
 internalDatabase: true
 
 sqlCellsApiHost: ""


### PR DESCRIPTION
There was no option to use existing config for Database credentials. This is usual case for EKS with ExternalSecrets operator that takes secret values from AWS SM. Now, there is an option to omit creation of the secret for the database and use existing one.