### PR TITLE
Adding extra volume mounts capabilities to Datalore statefulset.

### DIFF
--- a/charts/datalore/templates/statefulset.yaml
+++ b/charts/datalore/templates/statefulset.yaml
@@ -122,7 +122,6 @@ spec:
               name: plans-config
               subPath: plans_config.yaml
             {{- end }}
-            {{- end }}
             {{- if .Values.volumeMounts }}
             {{- toYaml .Values.volumeMounts | nindent 12 }}
             {{- end }}

--- a/charts/datalore/templates/statefulset.yaml
+++ b/charts/datalore/templates/statefulset.yaml
@@ -122,6 +122,10 @@ spec:
               name: plans-config
               subPath: plans_config.yaml
             {{- end }}
+            {{- end }}
+            {{- if .Values.volumeMounts }}
+            {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.dataloreResources | nindent 12 }}
         {{- if .Values.internalDatabase }}


### PR DESCRIPTION
The Datalore chart already allows to add extra Volumes to the definition of the statefulset, however we are not able to mount the volumes to the Datalore container.

This change allows to add extra Volume mounts to the Datalore container. This is particularly useful in cases where secrets are mounted via K8s Secrets Store CSI driver, example [here](https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/main/test/bats/tests/vault/pod-vault-inline-volume-secretproviderclass.yaml).